### PR TITLE
API change: Use `Property<File>` instead of `RegularFileProperty`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
-version=1.0.0
+version=1.1.0

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/GatherAggregateTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/GatherAggregateTask.kt
@@ -70,13 +70,13 @@ open class GatherAggregateTask @Inject constructor(
                 }.get()
                 val inputFile = PathUtil.summarizerFile(directory, state.summarizer)
 
-                state.ingestFile(inputFile)
+                state.ingestFile(inputFile.asFile)
             }
         }
 
         summarizerStates.forEach { state ->
             val outputFile = PathUtil.summarizerFile(outputDirectoryProperty.get(), state.summarizer)
-            state.write(outputFile)
+            state.write(outputFile.asFile)
         }
     }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/GatherHourlyTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/GatherHourlyTask.kt
@@ -153,7 +153,7 @@ open class GatherHourlyTask @Inject constructor(
             val outputDirectory = outputDirectoryProperty.get()
             summarizerStates.forEach { state ->
                 val outputFile = PathUtil.hourlySummarizerOutputFile(outputDirectory, state.summarizer)
-                state.write(outputFile)
+                state.write(outputFile.asFile)
             }
         }
     }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizer.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizer.kt
@@ -2,7 +2,7 @@ package com.ebay.plugins.metrics.develocity
 
 import com.ebay.plugins.metrics.develocity.service.model.Build
 import com.ebay.plugins.metrics.develocity.service.model.BuildModelName
-import org.gradle.api.file.RegularFile
+import java.io.File
 
 /**
  * Build data summarizer which can be used to process build data into an intermediate form,
@@ -25,12 +25,12 @@ abstract class MetricSummarizer<Intermediate> {
      * Reads intermediate data from a file.  If the file provided does not exist then the
      * method should return an empty intermediate data object.
      */
-    abstract fun read(file: RegularFile): Intermediate
+    abstract fun read(file: File): Intermediate
 
     /**
      * Writes an intermediate data object to the file specified.
      */
-    abstract fun write(intermediate: Intermediate, file: RegularFile)
+    abstract fun write(intermediate: Intermediate, file: File)
 
     /**
      * Processes a single build and produces an intermediate representation.

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizerState.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizerState.kt
@@ -1,7 +1,7 @@
 package com.ebay.plugins.metrics.develocity
 
 import com.ebay.plugins.metrics.develocity.service.model.Build
-import org.gradle.api.file.RegularFile
+import java.io.File
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -43,7 +43,7 @@ internal class MetricSummarizerState<T>(
      * Update the current state by reading the intermediate data from the given file and then
      * reducing it with the current state.
      */
-    fun ingestFile(file: RegularFile) {
+    fun ingestFile(file: File) {
         summarizer.read(file).let { intermediate ->
             update(intermediate)
         }
@@ -53,7 +53,7 @@ internal class MetricSummarizerState<T>(
      * Writes the current state to the file location specified.  If no data has been accumulated
      * then the file will not be written.
      */
-    fun write(file: RegularFile) {
+    fun write(file: File) {
         stateRef.get()?.let {
             summarizer.write(it, file)
         }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizerTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricSummarizerTask.kt
@@ -1,10 +1,11 @@
 package com.ebay.plugins.metrics.develocity
 
 import org.gradle.api.Task
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import java.io.File
 
 /**
  * Task properties which must exist on tasks which consume the summarizer output.
@@ -12,5 +13,5 @@ import org.gradle.api.tasks.PathSensitivity
 interface MetricSummarizerTask : Task {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
-    val summarizerDataProperty: RegularFileProperty
+    val summarizerDataProperty: Property<File>
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
@@ -71,7 +71,7 @@ private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
             val inputFileProvider = inputTask.flatMap { aggregateTask ->
                 PathUtil.summarizerFile(aggregateTask.outputDirectoryProperty, summarizerId)
             }
-            summarizerDataProperty.set(inputFileProvider)
+            summarizerDataProperty.set(inputFileProvider.map { it.asFile })
         }
     }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostSummarizer.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostSummarizer.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
-import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.File
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
@@ -37,9 +37,9 @@ class ProjectCostSummarizer(
     }
 
     @OptIn(ExperimentalSerializationApi::class) // decodeFromStream
-    override fun read(file: RegularFile): ProjectCostSummary {
-        return if (file.asFile.exists()) {
-            file.asFile.inputStream().use { inputStream ->
+    override fun read(file: File): ProjectCostSummary {
+        return if (file.exists()) {
+            file.inputStream().use { inputStream ->
                 BufferedInputStream(inputStream).use { buffered ->
                     if (compressOutput) {
                         GZIPInputStream(buffered).use { gzip ->
@@ -56,8 +56,8 @@ class ProjectCostSummarizer(
     }
 
     @OptIn(ExperimentalSerializationApi::class) // encodeToStream
-    override fun write(intermediate: ProjectCostSummary, file: RegularFile) {
-        file.asFile.outputStream().use { outputStream ->
+    override fun write(intermediate: ProjectCostSummary, file: File) {
+        file.outputStream().use { outputStream ->
             BufferedOutputStream(outputStream).use { buffered ->
                 if (compressOutput) {
                     GZIPOutputStream(buffered).use { gzip ->

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/userquery/UserQuerySummarizer.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/userquery/UserQuerySummarizer.kt
@@ -7,9 +7,9 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
-import org.gradle.api.file.RegularFile
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.File
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
@@ -30,9 +30,9 @@ class UserQuerySummarizer(
     }
 
     @OptIn(ExperimentalSerializationApi::class) // decodeFromStream
-    override fun read(file: RegularFile): UserQuerySummary {
-        return if (file.asFile.exists()) {
-            file.asFile.inputStream().use { inputStream ->
+    override fun read(file: File): UserQuerySummary {
+        return if (file.exists()) {
+            file.inputStream().use { inputStream ->
                 BufferedInputStream(inputStream).use { buffered ->
                     if (compressOutput) {
                         GZIPInputStream(buffered).use { gzip ->
@@ -49,8 +49,8 @@ class UserQuerySummarizer(
     }
 
     @OptIn(ExperimentalSerializationApi::class) // encodeToStream
-    override fun write(intermediate: UserQuerySummary, file: RegularFile) {
-        file.asFile.outputStream().use { outputStream ->
+    override fun write(intermediate: UserQuerySummary, file: File) {
+        file.outputStream().use { outputStream ->
             BufferedOutputStream(outputStream).use { buffered ->
                 if (compressOutput) {
                     GZIPOutputStream(buffered).use { gzip ->


### PR DESCRIPTION
In order to work towards converting the implementation over to use Gradle transforms, we have to switch to the use of an API that can be satisfied by a transform output.

Because this is an API change, the minor version was bumped.