### PR TITLE
Use a `PluginContext` class to extract plugin helper functions

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/PluginContext.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/PluginContext.kt
@@ -1,0 +1,17 @@
+package com.ebay.plugins.metrics.develocity
+
+import com.ebay.plugins.metrics.develocity.service.DevelocityBuildService
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+/**
+ * Helper class to made it easier for the plugin to pass these individual items all at once, as parameters,
+ * into internal function calls.
+ */
+internal data class PluginContext(
+    val project: Project,
+    val buildServiceProvider: Provider<DevelocityBuildService>,
+    val currentDayWithHourProvider: Provider<String>,
+    val dateHelper: DateHelper,
+    val ext: MetricsForDevelocityExtension,
+)


### PR DESCRIPTION
Basically, creates a manual closure in order to factor the task registration helpers out into private functions, in an attempt to get them out of the mental scope when looking at the plugin impl.