### PR TITLE
Provide mechanism for configuring tasks with Develocity configuration

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/DevelocityConfigurationInputs.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/DevelocityConfigurationInputs.kt
@@ -1,0 +1,22 @@
+package com.ebay.plugins.metrics.develocity
+
+import org.gradle.api.Task
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+
+/**
+ * Interface which may be added to a task to have it be auto-configured with the Develocity
+ * server configuration as applied to the root project in the [MetricsForDevelocityExtension].
+ *
+ * NOTE: Access to the Develosity access key is intentionally not provided here, as it is
+ * would potentially be exposed due to its use as part of the czche key.
+ */
+interface DevelocityConfigurationInputs : Task {
+    /**
+     * The Develocity server URL.  If the Gradle Develocity or Gradle Enterprise plugins are
+     * applied, this will be auto-configured by using the values applied to their respective
+     * extensions.
+     */
+    @get:Input
+    val develocityServerUrl: Property<String>
+}

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/DevelocityConfigurationInputs.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/DevelocityConfigurationInputs.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.Input
  * Interface which may be added to a task to have it be auto-configured with the Develocity
  * server configuration as applied to the root project in the [MetricsForDevelocityExtension].
  *
- * NOTE: Access to the Develosity access key is intentionally not provided here, as it is
+ * NOTE: Access to the Develocity access key is intentionally not provided here, as it is
  * would potentially be exposed due to its use as part of the czche key.
  */
 interface DevelocityConfigurationInputs : Task {

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -58,6 +58,10 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
                         }
                     }
                 }
+                // Configure tasks wanting to consume the Gradle Enterprise configuration:
+                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
+                    task.develocityServerUrl.set(gradleExt.server)
+                }
             }
         }
         settings.plugins.withId("com.gradle.develocity") {
@@ -70,6 +74,10 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
                             develocityAccessKey.convention(gradleExt.accessKey)
                         }
                     }
+                }
+                // Configure tasks wanting to consume the Develocity configuration:
+                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
+                    task.develocityServerUrl.set(gradleExt.server)
                 }
             }
         }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
@@ -88,7 +88,6 @@ internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummari
                 "$it/s/"
             }
         }
-        println("baseUrl: $baseUrl")
         val projectPathWithDelimiter = projectPath.get().let { if (it == ":") it else "$it:" }
         val buildScansReport = if (data.buildsWithExecution.isEmpty()) {
             "No builds with executed tasks\n\n"

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
@@ -1,5 +1,6 @@
 package com.ebay.plugins.metrics.develocity.projectcost
 
+import com.ebay.plugins.metrics.develocity.DevelocityConfigurationInputs
 import com.ebay.plugins.metrics.develocity.MetricSummarizerTask
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -15,12 +16,9 @@ import org.gradle.api.tasks.TaskAction
  * associated with the project.
  */
 @CacheableTask
-internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummarizerTask {
+internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummarizerTask, DevelocityConfigurationInputs {
     @get:OutputFile
     internal abstract val outputFile: RegularFileProperty
-
-    @get:Input
-    internal abstract val develocityUrl: Property<String>
 
     @get:Input
     internal abstract val projectPath: Property<String>
@@ -81,7 +79,7 @@ internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummari
                 separator = "\n\t",
                 postfix = "\n\n")
         }
-        val baseUrl = develocityUrl.orNull?.let {
+        val baseUrl = develocityServerUrl.orNull?.let {
             if (it.isEmpty()) {
                 ""
             } else if (it.endsWith("/")) {
@@ -90,6 +88,7 @@ internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummari
                 "$it/s/"
             }
         }
+        println("baseUrl: $baseUrl")
         val projectPathWithDelimiter = projectPath.get().let { if (it == ":") it else "$it:" }
         val buildScansReport = if (data.buildsWithExecution.isEmpty()) {
             "No builds with executed tasks\n\n"

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostPlugin.kt
@@ -76,15 +76,7 @@ internal class ProjectCostPlugin @Inject constructor(
                     outputFile.set(project.layout.buildDirectory.file("reports/projectCost/inspection.txt"))
                 }
             }
-
             project.plugins.withType(MetricsForDevelocityPlugin::class.java) {
-                // TODO: This violates project isolation
-                val serverUrlProp = project.rootProject.extensions.getByType(MetricsForDevelocityExtension::class.java).develocityServerUrl
-                taskProvider.configure { task ->
-                    with(task) {
-                        develocityUrl.set(serverUrlProp)
-                    }
-                }
                 taskProvider.inputsFromDuration(project, durationStr, ProjectCostSummarizer.ID)
             }
         }


### PR DESCRIPTION
Creates an interface which the plugin can use via `project.tasks.withType` in order to pass Develocity server configuration info into tasks that want to consume it.