### PR TITLE
Allow develocity server URL and access key to be provided via gradle property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,22 @@ extensions.configure<MetricsForDevelocityExtension> {
         // Configure the base URL of the Develocity server to query.  By default, the server URL
         // configured for the `com.gradle.enterprise` or `com.gradle.develocity` plugin/extension
         // will be used.
+        //
+        // If no Develocity plugin is applied, the value may also be set by defining a
+        // value for the `metricsForDevelocityServerUrl` gradle property.
         develocityServerUrl.set("https://custom-develocity-server.com")
 
         // Optional: Configure the access key to use when querying the Develocity server.
         // If an access key is explicitly provided to the `com.gradle.enterprise` or
-        // `com.gradle.develocity` extension, that value will be used as a default.  If no
-        // value is configured for this property then the Develocity key will be searched
+        // `com.gradle.develocity` extension, that value will be used as a default.
+        //
+        // If no value is configured for this property then the Develocity key will be searched
         // for in the standard locations for manual key provisioning, documented here:
         // https://docs.gradle.com/develocity/gradle-plugin/current/#manual_access_key_configuration
+        //
+        // If no Develocity plugin is applied, the value may also be set by defining a
+        // value for the `metricsForDevelocityAccessKey` gradle property.  If this approach
+        // is used, take care to ensure that the access key is not captured in the build scan.
         develocityAccessKey.set("your_base64_encoded_access_key")
         
         // Optional: Configure the query filter to use when querying the Develocity server for

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
@@ -17,6 +17,16 @@ object MetricsForDevelocityConstants {
     const val QUERY_FILTER_PROPERTY = "metricsForDevelocityQueryFilter"
 
     /**
+     *
+     */
+    const val DEVELOCITY_SERVER_URL_PROPERTY = "metricsForDevelocityServerUrl"
+
+    /**
+     *
+     */
+    const val DEVELOCITY_ACCESS_KEY_PROPERTY = "metricsForDevelocityAccessKey"
+
+    /**
      * The variant attribute used to identify what summarizer data is being exported or resolved.  The special
      * value of [SUMMARIZER_ALL] is used will result in a directory contianing all summarizer data.  Consumers
      * can start with this and apply a [SummarizerSelectTransform] to filter down to a single summarizer output.

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -1,5 +1,7 @@
 package com.ebay.plugins.metrics.develocity
 
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.DEVELOCITY_ACCESS_KEY_PROPERTY
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.DEVELOCITY_SERVER_URL_PROPERTY
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.EXTENSION_NAME
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.QUERY_FILTER_PROPERTY
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
@@ -101,6 +103,11 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             .apply {
                 zoneId.convention(ZoneId.systemDefault().id)
                 develocityMaxConcurrency.convention(24)
+
+                // NOTE: These conventions are overridden by Develocity plugin logic in the setting plugin portion
+                develocityServerUrl.convention(project.providers.gradleProperty(DEVELOCITY_SERVER_URL_PROPERTY))
+                develocityAccessKey.convention(project.providers.gradleProperty(DEVELOCITY_ACCESS_KEY_PROPERTY))
+
                 develocityQueryFilter.convention(
                     providerFactory.gradleProperty(QUERY_FILTER_PROPERTY)
                         .orElse("project:${project.name}"))

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.TaskProvider
  * Helper function to configure a task's inputs to use the outputs of of metric summarizer,
  * with the summary data spanning the datetime specified.
  */
-@Suppress("UnstableApiUsage")
 fun TaskProvider<out MetricSummarizerTask>.inputsFromDateTime(
     project: Project,
     timeSpec: String,
@@ -31,7 +30,6 @@ fun TaskProvider<out MetricSummarizerTask>.inputsFromDuration(
 /**
  * Common helper configuration for tasks which consume the summarizer output.
  */
-@Suppress("UnstableApiUsage")
 private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
     project: Project,
     inputConfiguration: String,


### PR DESCRIPTION
Added to allow for easier debugging of this plugin, configuring it via GRADLE_USER_HOME with private server access credentials.