### PR TITLE
Workaround Gradle issue with `Configuration`s created via rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ extensions.configure<MetricsForDevelocityExtension> {
         // If no value is configured for this property then the Develocity key will be searched
         // for in the standard locations for manual key provisioning, documented here:
         // https://docs.gradle.com/develocity/gradle-plugin/current/#manual_access_key_configuration
-        //
-        // If no Develocity plugin is applied, the value may also be set by defining a
-        // value for the `metricsForDevelocityAccessKey` gradle property.  If this approach
-        // is used, take care to ensure that the access key is not captured in the build scan.
         develocityAccessKey.set("your_base64_encoded_access_key")
         
         // Optional: Configure the query filter to use when querying the Develocity server for
@@ -89,6 +85,14 @@ which use the following forms:
   - `metricsForDevelocity-last-P2DT8H`: Queries all builds within the last 2 days and 8 hours.
   NOTE: When running queries which span multiple days, the plugin will automatically adjust the
   starting point to the beginning of the day if the start day is 7 days or more in the past.
+
+> [!IMPORTANT]
+> Due to a Gradle configuration issue, all time specifications used in the desired task(s) need
+> to be provided up-front via the `metricsForDevelocityConfigurations` gradle property, in a
+> comma delimited list.  For example, if running both the `metricsForDevelocity-last-PT8H` and
+> `metricsForDevelocity-2024-06-01T04` tasks, the following would be required:
+> `-PmetricsForDevelocityConfigurations=PT8H,2024-06-01T04`.  This is a workaround and is not
+> expected to be a permanent requirement of the plugin.
 
 ## Provided Summarizers
 

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
@@ -22,15 +22,34 @@ object MetricsForDevelocityConstants {
     const val DEVELOCITY_SERVER_URL_PROPERTY = "metricsForDevelocityServerUrl"
 
     /**
+     * Workaround for Gradle issue where configuration rules are not applied properly.  This
+     * property allows the plugin to pre-create configurations that will be needed for consumption
+     * in order to avoid the bug, which seems to only apply to configurations created via
+     * rule definition.
+     */
+    const val SUPPORTED_CONFIGURATION_PROPERTIES = "metricsForDevelocityConfigurations"
+
+    /**
+     * The variant attribute used to identify the time specification used to generate the
+     * summarizer data.  This is used to disambiguate the configuration when multiple
+     * instances are registered.
+     */
+    val TIME_SPEC_ATTRIBUTE: Attribute<String> = Attribute.of(
+        "com.ebay.metrics-for-develocity.time_spec", String::class.java
+    )
+
+    /**
      * The variant attribute used to identify what summarizer data is being exported or resolved.  The special
      * value of [SUMMARIZER_ALL] is used will result in a directory containing all summarizer data.  Consumers
      * can start with this and apply a [SummarizerSelectTransform] to filter down to a single summarizer output.
      */
-    val SUMMARIZER_ATTRIBUTE = Attribute.of("com.ebay.metrics-for-develocity.summarizer", String::class.java)
+    val SUMMARIZER_ATTRIBUTE: Attribute<String> = Attribute.of(
+        "com.ebay.metrics-for-develocity.summarizer", String::class.java
+    )
 
     /**
      * The attribute value used to identify the configuration used to export all summarizer data to
      * consuming projects.
      */
-    val SUMMARIZER_ALL = "_all_"
+    const val SUMMARIZER_ALL = "_all_"
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -5,12 +5,15 @@ import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.EXTENSI
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.QUERY_FILTER_PROPERTY
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
 import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.projectcost.ProjectCostPlugin
 import com.ebay.plugins.metrics.develocity.service.DevelocityBuildService
 import com.ebay.plugins.metrics.develocity.userquery.UserQueryPlugin
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
@@ -171,6 +174,19 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             ext,
         )
 
+        // As a workaround, pre-register configurations based upon a comma-delimited list of
+        // time specifications provided via gradle property.
+        project.providers.gradleProperty(SUPPORTED_CONFIGURATION_PROPERTIES).orNull?.let { propVal ->
+            propVal.split(",").forEach { configurationName ->
+                if (!pluginContext.registerConfigurationTimeSpec(configurationName)) {
+                    throw GradleException("Unable to parse time spec: $configurationName\n" +
+                            "\tSupported patterns:\n" +
+                            "\t\t'${DATETIME_TASK_PATTERN.pattern()}'\n" +
+                            "\t\t'${DURATION_TASK_PATTERN.pattern()}' (group 1 parsed as a Java duration)")
+                }
+            }
+        }
+
         /*
         * Creates a rule for generating consumable configurations for date time requests.
         * These can be scoped to daily or hourly time specifications.
@@ -179,28 +195,7 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             "Pattern: ${NameUtil.dateTime("<YYYY>-<MM>-<DD>[T<HH>]")}  " +
                     "Gathers Develocity metrics for the date (and optionally hour) specified."
         ) { configurationName ->
-            val matcher = DATETIME_TASK_PATTERN.matcher(configurationName)
-            if (!matcher.matches()) return@addRule
-
-            val date = matcher.group(2)
-            val timeSpec: String = matcher.group(1)
-            val hour: String? = matcher.group(3)
-
-            project.configurations.register(configurationName) { config ->
-                with(config) {
-                    isCanBeConsumed = true
-                    isCanBeResolved = false
-                    isTransitive = false
-                    attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
-                }
-            }
-
-            val artifactTaskProvider = if (hour == null) {
-                pluginContext.registerDaily(date)
-            } else {
-                pluginContext.registerHourly(timeSpec)
-            }
-            project.artifacts.add(configurationName, artifactTaskProvider)
+            pluginContext.registerDateTimeConfiguration(configurationName)
         }
 
         /*
@@ -212,20 +207,7 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
                     "Aggregates Develocity metrics for the current date back in time for the " +
                     "specified duration."
         ) { configurationName ->
-            val matcher = DURATION_TASK_PATTERN.matcher(configurationName)
-            if (!matcher.matches()) return@addRule
-
-            val durationStr: String = matcher.group(1)
-            val consumableConfig = project.configurations.register(configurationName)
-            consumableConfig.configure { config ->
-                with(config) {
-                    isCanBeConsumed = true
-                    isCanBeResolved = false
-                    isTransitive = false
-                    attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
-                }
-            }
-            project.artifacts.add(configurationName, pluginContext.registerDurationAggregation(durationStr))
+            pluginContext.registerDurationConfiguration(configurationName)
         }
 
         /*
@@ -265,6 +247,66 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             val durationStr: String = matcher.group(1)
             pluginContext.registerDurationAggregation(durationStr)
         }
+    }
+
+    private fun PluginContext.registerConfigurationTimeSpec(timeSpec: String): Boolean {
+        val dateTimeName = NameUtil.dateTime(timeSpec)
+        val durationName = NameUtil.duration(timeSpec)
+        return registerDateTimeConfiguration(dateTimeName)
+                || registerDurationConfiguration(durationName)
+    }
+
+    private fun PluginContext.registerDateTimeConfiguration(configurationName: String): Boolean {
+        val matcher = DATETIME_TASK_PATTERN.matcher(configurationName)
+        if (!matcher.matches()) return false
+
+        val date = matcher.group(2)
+        val timeSpec: String = matcher.group(1)
+        val hour: String? = matcher.group(3)
+
+        project.configurations.register(configurationName) { config ->
+            with(config) {
+                isCanBeConsumed = true
+                isCanBeResolved = false
+                isTransitive = false
+                attributes.attribute(TIME_SPEC_ATTRIBUTE, timeSpec)
+                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+            }
+        }
+
+        val artifactTaskProvider = if (hour == null) {
+            registerDaily(date)
+        } else {
+            registerHourly(timeSpec)
+        }
+        project.artifacts.add(configurationName, artifactTaskProvider)
+        return true
+    }
+
+    private fun PluginContext.registerDurationConfiguration(configurationName: String): Boolean {
+        val matcher = DURATION_TASK_PATTERN.matcher(configurationName)
+        if (!matcher.matches()) return false
+
+        val durationStr: String = matcher.group(1)
+
+        // Attempt to parse the duration string to ensure it is valid, prior to configuration
+        // registration.
+        val taskProvider = runCatching {
+            registerDurationAggregation(durationStr)
+        }.getOrNull() ?: return false
+
+        val consumableConfig = project.configurations.register(configurationName)
+        consumableConfig.configure { config ->
+            with(config) {
+                isCanBeConsumed = true
+                isCanBeResolved = false
+                isTransitive = false
+                attributes.attribute(TIME_SPEC_ATTRIBUTE, configurationName)
+                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+            }
+        }
+        project.artifacts.add(configurationName, taskProvider)
+        return true
     }
 
     /*

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
@@ -4,6 +4,7 @@ package com.ebay.plugins.metrics.develocity
 
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 
@@ -32,7 +33,7 @@ fun TaskProvider<out MetricSummarizerTask>.inputsFromDuration(
  */
 private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
     project: Project,
-    inputConfiguration: String,
+    configurationName: String,
     summarizerId: String,
 ) {
     // NOTE: It appears that `registerTransform` is reentrant so we don't have to worry about multiple invocations
@@ -44,20 +45,21 @@ private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
         }
     }
 
-    val resolveId = "$inputConfiguration-resolve"
+    val resolveId = "metricsForDevelocity-$configurationName-resolve"
     val resolveConfig = project.configurations.register(resolveId)
     resolveConfig.configure { config ->
         with(config) {
             isTransitive = false
             isCanBeResolved = true
             isCanBeConsumed = false
+            attributes.attribute(TIME_SPEC_ATTRIBUTE, configurationName)
             attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
 
             dependencies.add(
                 project.dependencies.project(
                     mapOf(
                         "path" to ":",
-                        "configuration" to inputConfiguration,
+                        "configuration" to configurationName,
                     )
                 )
             )

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/README.md
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/README.md
@@ -23,10 +23,15 @@ To generate the report, run the following command, replacing the project module 
 as desired:
 
 ```
-./gradlew :exampleModule:projectCostInspectionReport-P7D
+./gradlew -PmetricsForDevelocityConfigurations=P7D :exampleModule:projectCostInspectionReport-P7D
 ```
 
 Alternate durations may be specified by changing the `-P7D` suffix to the desired duration.
+
+> [!IMPORTANT]
+> To workaround a Gradle configuration issue, all time specifications used in the desired task need
+> to be provided up-front via the `metricsForDevelocityConfigurations` gradle property.  For more
+> information, please refer to the main [README](../../../../../../../../../README.md).
 
 ### Project Cost Graph Analytics Integration
 

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/userquery/README.md
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/userquery/README.md
@@ -16,8 +16,15 @@ used to provide a string in
 For example: 
 
 ```shell
-./gradlew '-PmetricsForDevelocityQueryFilter=tag:Local' userQueryReport-P7D
+./gradlew -PmetricsForDevelocityConfigurations=P7D \
+    '-PmetricsForDevelocityQueryFilter=tag:Local' \
+    userQueryReport-P7D
 ```
+
+> [!IMPORTANT]
+> To workaround a Gradle configuration issue, all time specifications used in the desired task need
+> to be provided up-front via the `metricsForDevelocityConfigurations` gradle property.  For more
+> information, please refer to the main [README](../../../../../../../../../README.md).
 
 Upon completion, the report will be written to a file based on the task name which was run,
 such as:


### PR DESCRIPTION
`Configuration` instances created by rules do not appear to have their "consumable" flags set properly, leading to failure in the consuming project.

This change allows the plugin to proactively create the configurations in the producing module by parsing a gradle property.  This allows us to work around the issue while the Gradle bug gets raised/fixed/etc.

Once the configurations were explicitly declared, this led to a disambiguation issue, resolved by adding an attribute to the configurations to distinguish them.

This fixes #27.
