### PR TITLE
Fix project cost report inclusion of extra `ms` text

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/ProjectCostInspectionTask.kt
@@ -39,7 +39,7 @@ internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummari
                 separator = "\n\t",
                 postfix = "\n\n"
             ) {
-                "${it.second} ms -- ${it.first} ms"
+                "${it.second} ms -- ${it.first}"
             }
         val topTasksByExecutions = data.taskNameToData.asSequence()
             .map { (taskName, taskData) ->
@@ -59,7 +59,7 @@ internal abstract class ProjectCostInspectionTask : DefaultTask(), MetricSummari
                 separator = "\n\t",
                 postfix = "\n\n"
             ) {
-                "${it.second} ms -- ${it.first} ms"
+                "${it.second} ms -- ${it.first}"
             }
         val topTypesByExecutions = data.taskTypeToData.asSequence()
             .map { (taskType, taskData) ->


### PR DESCRIPTION
As reported by Inaki:

The inspection output for the project cost has the unit repeated for Top 25 task types by average duration: and Top 25 tasks by average duration:. For instance:
```
Top 25 tasks by average duration:
	451980 ms -- testAndroid7_1_3 ms
	400679 ms -- testAndroid7_3_1 ms
	392192 ms -- testAndroid7_0_4 ms
	379243 ms -- testAndroid7_2_2 ms
	344726 ms -- testAndroid8_4_2 ms
	335430 ms -- testAndroid8_5_2 ms
	322421 ms -- testAndroid8_8_0_alpha05 ms
```
