### PR TITLE
Add config cache miss report capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ which use the following forms:
 This plugin ships with two example summarizer implementations which can be used as-is or
 can be used as a reference for how to add custom summarizers.  Please refer to the following
 documentation for more information on their purpose and usage:
+- [Config Cache Miss](src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/README.md)
 - [Project Cost](src/main/kotlin/com/ebay/plugins/metrics/develocity/projectcost/README.md)
 - [User Query](src/main/kotlin/com/ebay/plugins/metrics/develocity/userquery/README.md)
 
@@ -104,16 +105,16 @@ the plugin:
 
 ### Develocity API
 
-API Manual: https://docs.gradle.com/enterprise/api-manual/
-API Documentation: https://docs.gradle.com/enterprise/api-manual/ref/2022.4.html
+- API Manual: https://docs.gradle.com/enterprise/api-manual/
+- API Documentation: https://docs.gradle.com/enterprise/api-manual/ref/2022.4.html
 
 ### Gabriel Féo's `develocity-api-kotlin` Library
 
 This plugin uses the `develocity-api-kotlin` library to interact with the Develocity API
 rather than generating its own OpenAPI client.
 
-Repository: https://github.com/gabrielfeo/develocity-api-kotlin
-Kotlin API Documentation: https://gabrielfeo.github.io/develocity-api-kotlin/
+- Repository: https://github.com/gabrielfeo/develocity-api-kotlin
+- Kotlin API Documentation: https://gabrielfeo.github.io/develocity-api-kotlin/
 
 ## Licenses
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     implementation(libs.develocityApi)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.serializationJson)
+
+    testImplementation(libs.test.hamcrest)
+    testImplementation(libs.test.testng)
 }
 
 java {
@@ -48,6 +51,6 @@ project.tasks.withType(KotlinJvmCompile::class.java) {
 }
 
 project.tasks.withType(Test::class.java) {
-    useJUnitPlatform()
+    useTestNG()
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,12 +9,18 @@ kotlinx-coroutines = "1.8.1"
 # https://github.com/Kotlin/kotlinx.serialization/releases
 kotlinx-serializationJson = "1.6.3"
 
+test-hamcrest = "2.2"
+test-testng = "7.10.2"
+
 [libraries]
 develocityApi = { module = "com.gabrielfeo:develocity-api-kotlin", version.ref = "develocityApi" }
 gradle-develocity = { module = "com.gradle:develocity-gradle-plugin", version.ref = "gradle-develocity" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serializationJson" }
 pluginLib-ebay-graphAnalytics = { module = "com.ebay.graph-analytics:com.ebay.graph-analytics.gradle.plugin", version.ref = "ebay-graphAnalytics" }
+
+test-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "test-hamcrest" }
+test-testng = { module = "org.testng:testng", version.ref="test-testng" }
 
 [plugins]
 gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradle-pluginPublish" }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -5,6 +5,7 @@ import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.EXTENSI
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.QUERY_FILTER_PROPERTY
 import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
+import com.ebay.plugins.metrics.develocity.configcachemiss.ConfigCacheMissPlugin
 import com.ebay.plugins.metrics.develocity.projectcost.ProjectCostPlugin
 import com.ebay.plugins.metrics.develocity.service.DevelocityBuildService
 import com.ebay.plugins.metrics.develocity.userquery.UserQueryPlugin
@@ -109,6 +110,7 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
         }
 
         // Example summarizers
+        project.plugins.apply(ConfigCacheMissPlugin::class.java)
         project.plugins.apply(ProjectCostPlugin::class.java)
         project.plugins.apply(UserQueryPlugin::class.java)
     }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissPlugin.kt
@@ -1,0 +1,57 @@
+package com.ebay.plugins.metrics.develocity.configcachemiss
+
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityExtension
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityPlugin
+import com.ebay.plugins.metrics.develocity.inputsFromDuration
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * This plugin adds a summarizer and a report task that gathers a list of all the reasons
+ * why the config cache was missed, sorted by frequency, for builds
+ * matching the [com.ebay.plugins.metrics.develocity.MetricsForDevelocityPlugin] query filter.
+ */
+internal class ConfigCacheMissPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        if (project.parent == null) {
+            project.plugins.withType(MetricsForDevelocityPlugin::class.java) {
+                project.extensions.getByType(MetricsForDevelocityExtension::class.java).apply {
+                    summarizers.add(ConfigCacheMissSummarizer())
+                }
+            }
+
+            project.tasks.addRule(
+                "Pattern: $TASK_PREFIX-<Java Duration String>  " +
+                        "Creates a report showing all the reasons why the config cache resulted in " +
+                        "cache misses, for builds which matched the specified develocity query " +
+                        "filter."
+            ) { taskName ->
+                val matcher = TASK_PATTERN.matcher(taskName)
+                if (!matcher.matches()) return@addRule
+
+                val durationStr: String = matcher.group(1)
+                project.tasks.register(taskName, ConfigCacheMissReportTask::class.java).also { taskProvider ->
+                    taskProvider.configure { task ->
+                        with(task) {
+                            reportFile.set(project.layout.buildDirectory.file("reports/configCacheMiss/configCacheMiss-$durationStr.txt"))
+                        }
+                    }
+                    project.plugins.withType(MetricsForDevelocityPlugin::class.java) {
+                        taskProvider.inputsFromDuration(project, durationStr, ConfigCacheMissSummarizer.ID)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TASK_PREFIX = "configCacheMissReport"
+        private val TASK_PATTERN = Regex(
+            // Examples:
+            //      configCacheMissReport-P7D
+            //      configCacheMissReport-PT8H
+            //      configCacheMissReport-P2DT8H
+            "^\\Q$TASK_PREFIX-\\E(\\w+)$"
+        ).toPattern()
+    }
+}

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissReportTask.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissReportTask.kt
@@ -1,0 +1,123 @@
+package com.ebay.plugins.metrics.develocity.configcachemiss
+
+import com.ebay.plugins.metrics.develocity.MetricSummarizerTask
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import javax.inject.Inject
+
+/**
+ * Create a report of all config cache miss reasons, sorted by frequency.
+ */
+internal abstract class ConfigCacheMissReportTask @Inject constructor(
+    objectFactory: ObjectFactory,
+) : DefaultTask(), MetricSummarizerTask {
+    @get:Option(option = "pattern", description = "Pattern to consolidate/mutate the cache miss reasons")
+    @get:Input
+    val patterns: ListProperty<String> = objectFactory.listProperty(String::class.java)
+        .convention(listOf(
+            /*
+             * The following two patterns consolidate Intellij/AndroidStudio init script injections
+             * such as the following, into a single reason string:
+             *
+             * content of 2nd init script, '../../../../../private/var/folders/bn/66lrv12s3yx1hk_r_92r3fch0000gp/T/ijresolvers19.gradle', has changed
+             */
+            "(content of )[^ ]+ (init script)",
+            "\\.\\./[^ ]*(ijresolvers)[0-9]*(.gradle)",
+        ))
+
+    /**
+     * The output directory where the summarizer results should be stored.
+     */
+    @get:OutputFile
+    val reportFile: RegularFileProperty = objectFactory.fileProperty()
+
+    @TaskAction
+    fun createReport() {
+        val summaryFile = summarizerDataProperty.get()
+        val model = ConfigCacheMissSummarizer().read(summaryFile)
+        val regexes = patterns.get().map { it.toRegex() }
+        val reducedMap = reduceMap(model.reasons, regexes)
+        val report = reducedMap.map { entry ->
+                Pair(entry.value, entry.key)
+            }.sortedByDescending { (count, _) ->
+                count
+            }.joinToString(
+                prefix = "Config cache miss reason(s):\n    ",
+                separator = "\n    ",
+            ) { (count, reason) ->
+                "%5d: %s".format(count, reason)
+            }.replace("\n", System.lineSeparator())
+
+        reportFile.asFile.get().also { reportFile ->
+            logger.lifecycle("Config cache miss report available at: file://${reportFile.absolutePath}")
+            reportFile.writeText(report)
+        }
+    }
+
+    companion object {
+        /**
+         * (Potentially) reduces the map of reasons by running the reasons through a filter
+         * of regular expressions.  This allows multiple similar reasons to be consolidated
+         * into a single reason for consumption purposes.  See [reduceKey] for more details
+         * on the consolidation logic.
+         */
+        internal fun reduceMap(originalMap: Map<String, Int>, regexes: List<Regex>): Map<String, Int> {
+            val reducedMap = mutableMapOf<String, Int>()
+            originalMap.forEach { (reason, count) ->
+                reducedMap.compute(reduceKey(reason, regexes)) { _, existingCount ->
+                    (existingCount ?: 0) + count
+                }
+            }
+            return reducedMap.toMap()
+        }
+
+        /**
+         * Determines a new key value by running the provided key value through a filtering process.
+         * The filtering is performed by applying a list of regular expressions.
+         *
+         * The behavior of these regular expressions is broken into two categories; those that
+         * define capturing groups and those that do not.
+         *
+         * For regular expressions which do not define capturing groups, the any matches within
+         * the key are removed from the key.
+         *
+         * For regular expressions which do define capturing groups, the matched portion of the
+         * key is replaced with a concatenation of all defined capturing group values.  This
+         * allows portions of the match to be retained.
+         */
+        internal fun reduceKey(originalKey: String, regexes: List<Regex>): String {
+            if (regexes.isEmpty()) {
+                return originalKey
+            }
+
+            var newKey = originalKey
+            regexes.forEach { regex ->
+                while(true) {
+                    val matchResult = regex.find(newKey) ?: break
+                    val nextKey = if (matchResult.groups.size == 1) {
+                        // Only one group (0) so assume we want to strip these matches.
+                        newKey.removeRange(matchResult.range)
+                    } else {
+                        // Multiple groups match.  Concatenate groups >= 1.
+                        val replacement = matchResult.groups.drop(1).joinToString(separator = "") { matchGroup ->
+                            matchGroup?.value ?: ""
+                        }
+                        newKey.replaceRange(matchResult.range, replacement)
+                    }
+                    if (nextKey == newKey) {
+                        break
+                    } else {
+                        newKey = nextKey
+                    }
+                }
+            }
+            return newKey
+        }
+    }
+}

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissSummarizer.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissSummarizer.kt
@@ -1,0 +1,78 @@
+package com.ebay.plugins.metrics.develocity.configcachemiss
+
+import com.ebay.plugins.metrics.develocity.MetricSummarizer
+import com.gabrielfeo.develocity.api.model.Build
+import com.gabrielfeo.develocity.api.model.BuildModelName
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+
+/**
+ * [MetricSummarizer] implementation which collects configuration cache miss reason data.
+ */
+class ConfigCacheMissSummarizer: MetricSummarizer<ConfigCacheMissSummary>() {
+    override val id = ID
+    override val modelsNeeded = setOf(
+        BuildModelName.gradleConfigurationCache,
+    )
+
+    private val serializer by lazy {
+        ConfigCacheMissSummary.serializer()
+    }
+
+    @OptIn(ExperimentalSerializationApi::class) // decodeFromStream
+    override fun read(file: File): ConfigCacheMissSummary {
+        return if (file.exists()) {
+            file.inputStream().use { inputStream ->
+                BufferedInputStream(inputStream).use { buffered ->
+                    prettyJson.decodeFromStream(serializer, buffered)
+                }
+            }
+        } else {
+            ConfigCacheMissSummary()
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class) // encodeToStream
+    override fun write(intermediate: ConfigCacheMissSummary, file: File) {
+        file.outputStream().use { outputStream ->
+            BufferedOutputStream(outputStream).use { buffered ->
+                prettyJson.encodeToStream(serializer, intermediate, buffered)
+            }
+        }
+    }
+
+    override fun extract(build: Build): ConfigCacheMissSummary {
+        val observations: MutableMap<String, Int> = mutableMapOf()
+        build.models?.gradleConfigurationCache?.model?.result?.missReasons?.forEach { reason ->
+            observations.compute(reason) { _, count -> (count ?: 0) + 1 }
+        }
+        return ConfigCacheMissSummary(
+            reasons = observations,
+        )
+    }
+
+    override fun reduce(left: ConfigCacheMissSummary, right: ConfigCacheMissSummary): ConfigCacheMissSummary {
+        val observations = left.reasons.toMutableMap()
+        right.reasons.forEach { (reason, count) ->
+            observations.compute(reason) { _, currentCount -> (currentCount ?: 0) + count }
+        }
+        return ConfigCacheMissSummary(
+            reasons = observations,
+        )
+    }
+
+    companion object {
+        const val ID = "configCacheMissReasons"
+
+        @OptIn(ExperimentalSerializationApi::class)
+        val prettyJson = Json { // this returns the JsonBuilder
+            prettyPrint = true
+            prettyPrintIndent = " "
+        }
+    }
+}

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissSummary.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissSummary.kt
@@ -1,0 +1,12 @@
+package com.ebay.plugins.metrics.develocity.configcachemiss
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Intermediate data model used to aggregate a set of reasons for cache misses along with their
+ * observed counts.
+ */
+@Serializable
+data class ConfigCacheMissSummary(
+    val reasons: Map<String, Int> = emptyMap(),
+)

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/README.md
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/README.md
@@ -1,0 +1,58 @@
+# Config Cache Miss Plugin
+
+
+## Usage
+
+This plugin defines a task name rule which can be used to generate a report of all
+config cache miss reasons along with their frequency.  The task name specification
+is of the form: `configCacheMissReport-<duration>`, where `<duration>` is a Java time duration
+string ([JavaDocs](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html)).
+
+## Query Filter
+
+In order to specify the query criteria, the Develocity Metrics Plugin's query property is
+used to provide a string in
+[Develocity advanced search syntax](https://docs.gradle.com/enterprise/api-manual/#advanced_search_syntax).
+For example: 
+
+```shell
+./gradlew '-PmetricsForDevelocityQueryFilter=tag:Local' configCacheMissReport-P7D
+```
+
+## Consolidating Similar Lines
+
+Many of the reported cache miss reasons may look nearly identical, but have some variations
+that are not important for reporting purposes.  These variations can be consolidated by
+providing one or more regular expressions to the reporting task.
+
+Each regular expression is applied to the cache miss reason, and if a match is found, the
+behavior will vary based upon how the regular expression is defined:
+- If the regular expression contains no capture groups, then the portion of the reason string
+  that matches will be removed.  For example, if the regular expression is ` two ` and the
+  reason is `one two three`, the resulting reason will be `onethree`.
+- If the regular expression defines one or more capture groups, then the portion of the reason
+  string that matches the regular expression will be replaced by a concatenation of all non-null
+  capture groups.  For example, if the regular expression is ` (two) ` and the reason is
+  `one two three`, the resulting reason will be `onetwothree`.
+
+These rules can be used to simplify reason lines to make them identical, allowing them to be
+bucketed together in the final report.
+
+To specify a regular expression to be used in this manner, simply add the `--pattern <regex>`
+argument after the task name.  For example:
+
+```shell
+./gradlew configCacheMissReport-P7D --pattern '(one) ' --pattern ' (three)'
+```
+
+By convention, some rules are applied if no patterns are provided. See the following code
+for the default rules: [ConfigCacheMissReportTask.kt](ConfigCacheMissReportTask.kt#L22)
+
+## Output
+
+Upon completion, the report will be written to a file based on the task name which was run,
+such as:
+```shell
+build/reports/configCacheMiss/configCacheMiss-P7D.txt
+```
+The report location will be printed to the console as task execution completes.

--- a/src/test/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissReportTaskTest.kt
+++ b/src/test/kotlin/com/ebay/plugins/metrics/develocity/configcachemiss/ConfigCacheMissReportTaskTest.kt
@@ -1,0 +1,71 @@
+package com.ebay.plugins.metrics.develocity.configcachemiss
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.sameInstance
+import org.testng.annotations.Test
+
+class ConfigCacheMissReportTaskTest {
+
+    @Test
+    fun reduceKeyWithNoRegexes() {
+        val expected = "original"
+        val reducedKey = ConfigCacheMissReportTask.Companion.reduceKey(expected, emptyList())
+        assertThat(reducedKey, sameInstance(expected))
+    }
+
+    @Test
+    fun reduceKeyWithNoDefinedMatchGroups() {
+        val expected = "one two three"
+        val regex = Regex("two ")
+        val reducedKey = ConfigCacheMissReportTask.Companion.reduceKey(expected, listOf(regex))
+        assertThat(reducedKey, equalTo("one three"))
+    }
+
+    @Test
+    fun reduceKeyWithOneMatchGroup() {
+        val expected = "one two three"
+        val regex = Regex(" (two) ")
+        val reducedKey = ConfigCacheMissReportTask.Companion.reduceKey(expected, listOf(regex))
+        assertThat(reducedKey, equalTo("onetwothree"))
+    }
+
+    @Test
+    fun reduceKeyWithMultipleMatchGroups() {
+        val expected = "xone two threex"
+        val regex = Regex("(one).*(three)")
+        val reducedKey = ConfigCacheMissReportTask.Companion.reduceKey(expected, listOf(regex))
+        assertThat(reducedKey, equalTo("xonethreex"))
+    }
+
+    @Test
+    fun reduceKeyWithMultipleMatchGroupsInMultiplePatterns() {
+        val expected = "xone two threex"
+        val regexes = listOf(
+            Regex("one "),
+            Regex(" three"),
+        )
+        val reducedKey = ConfigCacheMissReportTask.Companion.reduceKey(expected, regexes)
+        assertThat(reducedKey, equalTo("xtwox"))
+    }
+
+    @Test
+    fun reduceMap() {
+        val inputMap = mapOf(
+            "first second third" to 2,
+            "first 2 third" to 3,
+        )
+        val regexes = listOf(
+            " second".toRegex(),
+            " 2".toRegex(),
+        )
+        val reducedMap = ConfigCacheMissReportTask.Companion.reduceMap(inputMap, regexes)
+        assertThat(reducedMap.entries, hasSize(equalTo(1)))
+        assertThat(reducedMap, allOf(
+            hasEntry(equalTo("first third"), equalTo(5)),
+        ))
+    }
+}


### PR DESCRIPTION
Adds a new report which gives a pareto-style breakdown of all the reasons why the config cache missed.  This can be used to work towards improving the config cache hit rate for MOAR SPEED.