### PR TITLE
Restore configuration-based approach for task wiring

### DIFF
--- a/docs/Design.md
+++ b/docs/Design.md
@@ -37,6 +37,58 @@ Time window tasks (e.g., last 7 days)
 
 All data gathering tasks are performed only in the root project.
 
+## Consumable `Configuration`s
+
+In order to expose the root project's data to the consuming projects the root project defines
+consumable `Configuration`s which export the data produced by the data gathering tasks to the
+consuming projects.  These `Configuration`s use the same naming conventions as the data gathering
+tasks.
+
+### Pre-created `Configuration`s
+
+In order for the consuming projects to be able to consume the data produced by the root
+project's data gathering mechanisms from sub-projects, the root project needs to be instructed
+as to what `Configuration`s to pre-create.  This is due to the fact that the desired
+`Configuration` must exist at configuration time.
+
+There are two mechanisms built to satisfy this requirement:
+- When the plugin is applied as a settings plugin, it will look at the requested task list for any
+  task name which is suffixed with `-<timeSpec>`, where `<timeSpec>` may either be a datetime
+  specification (e.g. `2024-10-21`) or a duration specification (e.g. `P7D`).  The plugin will
+  then automatically pre-create the `Configuration` for the task with no additional effort required.
+- If the task name detection approach does not satisfy the underlying requirement of the consuming
+  project (e.g., if the task name does not contain a time specification) then the
+  `metricsForDevelocityConfigurations` gradle property may be supplied with a comma-delimited
+  list of time specifications to automatically pre-create the configurations for.  This is a
+  bit hacky, but works in lie of a Gradle API being created to allow for dynamic configuration
+  creation (xref: https://github.com/gradle/gradle/issues/30831).
+
+### Basic task wiring
+
+To simplify the chore of wiring up the consuming projects, the
+[TaskProviderExtensions](../src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt)
+file provides a set of extension functions that can be used to wire up an individual
+summarizer's output of the data gathering task to a consuming project's
+`TaskProvider<out MetricSummarizerTask>` instance.
+
+### Advanced task wiring
+
+For more advanced use cases where the provided extensions are inadequate, the consuming
+project can create a resolvable Gradle `Configuration` to refer to the root project's
+`Configuration` by name and attribute configuration.  When this approach is used, the resolvable
+`Configuration` should specify the following attributes:
+- [SUMMARIZER_ATTRIBUTE](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
+  with a value of [SUMMARIZER_ALL], which will result in a directory of all summarizer outputs.
+- [TIME_SPEC_ATTRIBUTE](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
+  with a value of the datetime or duration specification (e.g., `2024-10-21` or `P7D`)
+
+At this point, the summarizer output file would ideally be selected via an artifact transform
+provided by this plugin.  Unfortunately, the Gradle API for this is not quite workable at this
+time.  For now, simply use the output directory provided and resolve the file named with the
+summarizer's ID, directly.  See the
+[TaskProviderExtensions](../src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt)
+helper method implementations for an example of how this is done.
+
 ## Data consumer / reporting tasks
 
 Data consumer / reporting tasks are configured to consume the aggregated data from the first

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
@@ -20,4 +20,44 @@ object MetricsForDevelocityConstants {
      * Gradle property which can be used to configure the Develocity server URL.
      */
     const val DEVELOCITY_SERVER_URL_PROPERTY = "metricsForDevelocityServerUrl"
+
+    /**
+     * Workaround for Gradle API issue where configuration rules are not applied dynamically as the
+     * API appears it should (xref: https://github.com/gradle/gradle/issues/30831).  This
+     * property allows for the pre-creation of configurations that will be needed for consumption
+     * in order to avoid the bug, which seems to only apply to configurations created via
+     * rule definition.
+     */
+    const val SUPPORTED_CONFIGURATION_PROPERTIES = "metricsForDevelocityConfigurations"
+
+    /**
+     * Property name used by the settings plugin to auto-detect the configurations that should
+     * be supported.  This works by inspecting the task names of the requested tasks, looking
+     * for task names that appear to have a time specification suffix.
+     */
+    internal const val SUPPORTED_CONFIGURATION_PROPERTIES_AUTO = "metricsForDevelocityAutomaticConfigurations"
+
+    /**
+     * The variant attribute used to identify the time specification used to generate the
+     * summarizer data.  This is used to disambiguate the configuration when multiple
+     * instances are registered.
+     */
+    val TIME_SPEC_ATTRIBUTE: Attribute<String> = Attribute.of(
+        "com.ebay.metrics-for-develocity.time_spec", String::class.java
+    )
+
+    /**
+     * The variant attribute used to identify what summarizer data is being exported or resolved.
+     * The special value of [SUMMARIZER_ALL] is used will result in a directory containing all
+     * summarizer data.  All other values should be considered reserved at this time.
+     */
+    val SUMMARIZER_ATTRIBUTE: Attribute<String> = Attribute.of(
+        "com.ebay.metrics-for-develocity.summarizer", String::class.java
+    )
+
+    /**
+     * The attribute value used to identify the configuration used to export all summarizer data to
+     * consuming projects.
+     */
+    const val SUMMARIZER_ALL = "_all_"
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -523,8 +523,4 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             }
         }
     }
-
-    companion object {
-        internal const val INTERNAL_EXTENSION_NAME = "metricsForDevelocityInternal"
-    }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -3,13 +3,21 @@ package com.ebay.plugins.metrics.develocity
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.DEVELOCITY_SERVER_URL_PROPERTY
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.EXTENSION_NAME
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.QUERY_FILTER_PROPERTY
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES_AUTO
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_SUFFIX_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
+import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_SUFFIX_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.configcachemiss.ConfigCacheMissPlugin
 import com.ebay.plugins.metrics.develocity.projectcost.ProjectCostPlugin
 import com.ebay.plugins.metrics.develocity.service.DevelocityBuildService
 import com.ebay.plugins.metrics.develocity.userquery.UserQueryPlugin
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
@@ -102,9 +110,36 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
                 }
             }
         }
+
+        // Look for task names that have a datetime or duration suffix and feed those into a property that the
+        // plugin can consume in order to pro-actively create the consumable configurations.
+        settings.gradle.lifecycle.beforeProject { project ->
+            if (project.parent == null) {
+                val requestedTimeSpecs = mutableListOf<String>()
+                project.gradle.startParameter.taskRequests.forEach { taskRequest ->
+                    taskRequest.args.forEach { taskName ->
+                        DATETIME_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
+                            matchResult.groups[1]?.value?.let {
+                                requestedTimeSpecs.add(it)
+                            }
+                        }
+                        DURATION_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
+                            matchResult.groups[1]?.value?.let {
+                                requestedTimeSpecs.add(it)
+                            }
+                        }
+                    }
+                }
+                val autoProperties = requestedTimeSpecs.joinToString(separator = ",")
+                project.extensions.extraProperties.set(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO, autoProperties)
+            }
+        }
     }
 
     private fun applyProject(project: Project) {
+        project.dependencies.attributesSchema.attribute(SUMMARIZER_ATTRIBUTE)
+        project.dependencies.attributesSchema.attribute(TIME_SPEC_ATTRIBUTE)
+
         if (project.parent == null) {
             applyRootProject(project)
         }
@@ -175,6 +210,35 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             ext,
         )
 
+        // As a workaround, pre-register configurations based upon a comma-delimited list of
+        // time specifications provided via gradle properties.
+        val requestedTimeSpecs = buildSet {
+            // The "auto" property is automatically populated via the settings plugin.
+            val extProps = project.extensions.extraProperties
+            //if (extProps.has(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO)) {
+                addAll(
+                    extProps.get(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO)
+                        ?.toString()
+                        ?.split(",")
+                        ?: emptyList()
+                )
+            //}
+            // The "manual" property can be used by the end user for situations where the "auto"
+            // property is inadequate.
+            addAll(project.providers.gradleProperty(SUPPORTED_CONFIGURATION_PROPERTIES)
+                .orNull
+                ?.split(",")
+                ?: emptyList())
+        }
+        requestedTimeSpecs.forEach { timeSpec ->
+            if (timeSpec.isNotBlank() && !pluginContext.registerConfigurationTimeSpec(timeSpec)) {
+                throw GradleException("Unable to parse time spec: $timeSpec\n" +
+                        "\tSupported patterns:\n" +
+                        "\t\t'${DATETIME_TASK_PATTERN.pattern()}'\n" +
+                        "\t\t'${DURATION_TASK_PATTERN.pattern()}' (group 1 parsed as a Java duration)")
+            }
+        }
+
         /*
          * Rule to register a task for a specific date and optionally hour.
          */
@@ -212,14 +276,77 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
             val durationStr: String = matcher.group(1)
             pluginContext.registerDurationAggregation(durationStr)
         }
+    }
 
-        ext.extensions.create(
-            INTERNAL_EXTENSION_NAME,
-            MetricsForDevelocityInternalExtension::class.java,
-            { timeSpec: String -> pluginContext.registerHourly(timeSpec) },
-            { dateStr: String -> pluginContext.registerDaily(dateStr) },
-            { durationStr: String -> pluginContext.registerDurationAggregation(durationStr) },
-        )
+    /**
+     * Function to attempt pro-active creation of a consumable configuration for the provided
+     * datetime or duration specification (AKA, time spec).
+     *
+     * @return `true` if the configuration was created, `false` otherwise
+     */
+    private fun PluginContext.registerConfigurationTimeSpec(timeSpec: String): Boolean {
+        val dateTimeName = NameUtil.dateTime(timeSpec)
+        val durationName = NameUtil.duration(timeSpec)
+        return registerDateTimeConfiguration(dateTimeName)
+                || registerDurationConfiguration(durationName)
+    }
+
+    /**
+     * Function to the creation of a consumable configuration for a provided datetime time specification.
+     *
+     * @return `true` if the configuration was created, `false` otherwise
+     */
+    private fun PluginContext.registerDateTimeConfiguration(configurationName: String): Boolean {
+        val matcher = DATETIME_TASK_PATTERN.matcher(configurationName)
+        if (!matcher.matches()) return false
+
+        val timeSpec: String = matcher.group(1)
+        val date = matcher.group(2)
+        val hour: String? = matcher.group(3)
+
+        project.configurations.consumable(configurationName) { config ->
+            with(config) {
+                isTransitive = false
+                attributes.attribute(TIME_SPEC_ATTRIBUTE, timeSpec)
+                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+            }
+        }
+
+        val artifactTaskProvider = if (hour == null) {
+            registerDaily(date)
+        } else {
+            registerHourly(timeSpec)
+        }
+        project.artifacts.add(configurationName, artifactTaskProvider)
+        return true
+    }
+
+    /**
+     * Function to the creation of a consumable configuration for a provided duration time specification.
+     *
+     * @return `true` if the configuration was created, `false` otherwise
+     */
+    private fun PluginContext.registerDurationConfiguration(configurationName: String): Boolean {
+        val matcher = DURATION_TASK_PATTERN.matcher(configurationName)
+        if (!matcher.matches()) return false
+
+        val durationStr: String = matcher.group(1)
+
+        // Attempt to parse the duration string to ensure it is valid, prior to configuration
+        // registration.
+        val taskProvider = runCatching {
+            registerDurationAggregation(durationStr)
+        }.getOrNull() ?: return false
+
+        project.configurations.consumable(configurationName) { config ->
+            with(config) {
+                isTransitive = false
+                attributes.attribute(TIME_SPEC_ATTRIBUTE, durationStr)
+                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+            }
+        }
+        project.artifacts.add(configurationName, taskProvider)
+        return true
     }
 
     /*

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -215,14 +215,14 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
         val requestedTimeSpecs = buildSet {
             // The "auto" property is automatically populated via the settings plugin.
             val extProps = project.extensions.extraProperties
-            //if (extProps.has(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO)) {
+            if (extProps.has(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO)) {
                 addAll(
                     extProps.get(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO)
                         ?.toString()
                         ?.split(",")
                         ?: emptyList()
                 )
-            //}
+            }
             // The "manual" property can be used by the end user for situations where the "auto"
             // property is inadequate.
             addAll(project.providers.gradleProperty(SUPPORTED_CONFIGURATION_PROPERTIES)

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -48,7 +48,7 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
     }
 
     private fun applySettings(settings: Settings) {
-        settings.gradle.beforeProject { project ->
+        settings.gradle.lifecycle.beforeProject { project ->
             project.plugins.apply(MetricsForDevelocityPlugin::class.java)
         }
 

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/NameUtil.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/NameUtil.kt
@@ -4,13 +4,56 @@ package com.ebay.plugins.metrics.develocity
  * Utility functions for generating task names, to keep it all in one place.
  */
 internal object NameUtil {
-    const val TASK_PREFIX = "metricsForDevelocity"
+    private const val TASK_PREFIX = "metricsForDevelocity"
+
+    /**
+     * Pattern to match the date portion of a datetime string.
+     */
+    private const val DATE_PATTERN = "\\d{4}-\\d{2}-\\d{2}"
+
+    /**
+     * Pattern to match the hour portion of a datetime string.
+     */
+    private const val HOUR_PATTERN = "\\d{2}"
+
+    /**
+     * Pattern to match the subset of the `Duration` string format defined by Java:
+     * https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)
+     *
+     * We only support days and hours, and we don't support minutes or seconds.
+     * We also only support positive duration values.
+     */
+    private const val DURATION_PATTERN =
+        "[pP](?:[0-9]+[dD])?(?:T(?:[0-9]+[hH]?)?)?"
+
+    /**
+     * Regular expression used to match requested task names that have a name suffixed by a datetime specification.
+     *
+     * Examples:
+     * - metricsForDevelocity-2024-10-18
+     * - speedReport-2024-10-18T09
+     */
+    internal val DATETIME_SUFFIX_PATTERN = Regex(
+        ".*-($DATE_PATTERN(?:T${HOUR_PATTERN})?)$"
+    )
+
+    /**
+     * Regular expression used to match requested task names that have a name suffixed by a duration specification.
+     *
+     * Examples:
+     * - metricsForDevelocity-last-P7D
+     * - speedReport-P2DT12H
+     * - bobsReport-PT8H
+     */
+    internal val DURATION_SUFFIX_PATTERN = Regex(
+        ".*-($DURATION_PATTERN)$"
+    )
 
     val DATETIME_TASK_PATTERN = Regex(
         // Examples:
         //      metricsForDevelocity-2024-06-01
         //      metricsForDevelocity-2024-06-01T05
-        "^\\Q$TASK_PREFIX-\\E((\\d{4}-\\d{2}-\\d{2})(?:T(\\d{2}))?)$"
+        "^\\Q$TASK_PREFIX-\\E(($DATE_PATTERN)(?:T(${HOUR_PATTERN}))?)$"
     ).toPattern()
 
     val DURATION_TASK_PATTERN = Regex(
@@ -18,7 +61,7 @@ internal object NameUtil {
         //      metricsForDevelocity-last-P7D
         //      metricsForDevelocity-last-PT8H
         //      metricsForDevelocity-last-P2DT8H
-        "^\\Q$TASK_PREFIX-last-\\E(\\w+)$"
+        "^\\Q$TASK_PREFIX-last-\\E($DURATION_PATTERN)$"
     ).toPattern()
 
     fun dateTime(timeSpec: String): String = "$TASK_PREFIX-$timeSpec"


### PR DESCRIPTION
Restores the configuration-based approach for wiring up tasks in sub-projects to the data production in the root project module.

The limitation with this approach is that there is currently no mechanism for dynamically creating consumable configurations on-demand [xref](https://github.com/gradle/gradle/issues/30831).  As a result, all the configurations must be pre-created at configuration-time.  A new gradle property is defined to allow a comma-separated list of time specifications to be provided to the plugin to pre-create the needed consumable configurations.

While the above workaround is adequate, it is a pain to actually use.  To make the common use case more convenient, the settings plugin was updated to scan the list of requested tasks, looking for task names with a suffix that looks like a supported time specification.  When found, the consumable configurations are automatically added, allowing sub-projects to defined task rules based upon datetime/duration specifications and preventing the need for any additional manual specification via gradle property.

This PR removes the known hurdles to project isolation, though this functionality remains untested.