### PR TITLE
Split out the settings plugin into a dedicated (and primary) plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ gradlePlugin {
     plugins {
         create("metricsForDevelocity") {
             id = "com.ebay.metrics-for-develocity"
-            implementationClass = "com.ebay.plugins.metrics.develocity.MetricsForDevelocityPlugin"
+            implementationClass = "com.ebay.plugins.metrics.develocity.MetricsForDevelocitySettingsPlugin"
             displayName = "Metrics for Develocity Plugin"
             description = "Gradle plugin which provides a framework for reporting on Develocity build data"
             tags = listOf(

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     `embedded-kotlin`
-    id("com.ebay.metrics-for-develocity")
 }
 
 java {

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityPlugin.kt
@@ -1,0 +1,16 @@
+package com.ebay.plugins.metrics.develocity
+
+import org.gradle.api.Plugin
+
+/**
+ * Plugin indirection layer, allowing the plugin ID to be applied to either a project or settings.
+ *
+ * We use this indirection layer to allow for the plugin's application to be uniformly detected
+ * via this class, irrespective of the underlying implementation class.  This allows plugin
+ * authors to guard access to the extensions with code such as the following:
+ *
+ * ```kotlin
+ * project.plugins.withType(MetricsForDevelocityPlugin::class.java) { ... }
+ * ```
+ */
+interface MetricsForDevelocityPlugin<T> : Plugin<T>

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
@@ -8,19 +8,14 @@ import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARI
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES_AUTO
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
-import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_SUFFIX_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
-import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_SUFFIX_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.configcachemiss.ConfigCacheMissPlugin
 import com.ebay.plugins.metrics.develocity.projectcost.ProjectCostPlugin
 import com.ebay.plugins.metrics.develocity.service.DevelocityBuildService
 import com.ebay.plugins.metrics.develocity.userquery.UserQueryPlugin
-import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import org.gradle.api.GradleException
-import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.initialization.Settings
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import java.time.Duration
@@ -34,109 +29,11 @@ import javax.inject.Inject
  * Plugin implementation which defines tasks and configurations artifacts which are used to
  * generate aggregate metric data based upon Develocity build scans.
  */
-@Suppress("unused") // False positive
 internal class MetricsForDevelocityProjectPlugin @Inject constructor(
     private val providerFactory: ProviderFactory
-) : Plugin<Any> {
+) : MetricsForDevelocityPlugin<Project> {
 
-    override fun apply(target: Any) {
-        when(target) {
-            is Project -> applyProject(target)
-            is Settings -> applySettings(target)
-            else -> throw IllegalArgumentException("Unsupported plugin target type: ${target::class.java}")
-        }
-    }
-
-    private fun applySettings(settings: Settings) {
-        settings.gradle.lifecycle.beforeProject { project ->
-            project.plugins.apply(MetricsForDevelocityProjectPlugin::class.java)
-        }
-
-        // If we are using the gradle property to configure the develocity URL, pass this
-        // info into the tasks that may consume it.  This is used in preference to the
-        // value configured by the develocity or gradle enterprise plugins, when applied.
-        settings.providers.gradleProperty(DEVELOCITY_SERVER_URL_PROPERTY).orNull?.let { url ->
-            settings.gradle.beforeProject { project ->
-                project.tasks.withType(DevelocityConfigurationInputs::class.java) { task ->
-                    // `set` instead of `convention` since specification by property value should
-                    // take precedence over the default value.
-                    task.develocityServerUrl.set(url)
-                }
-            }
-        }
-
-        // Auto-configure the Gradle Enterprise access if the plugin is applied and has been
-        // directly configured with a server URL and/or access key.
-        settings.plugins.withId("com.gradle.enterprise") {
-            // The Develocity plugin is also registered under this ID so we need to avoid running
-            // this logic when this is the case.
-            if (settings.plugins.hasPlugin("com.gradle.develocity")) {
-                return@withId
-            }
-
-            @Suppress("DEPRECATION") // GradleEnterpriseExtension is deprecated
-            val gradleExt = settings.extensions.getByType(com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension::class.java)
-            settings.gradle.afterProject { project ->
-                project.plugins.withId("com.ebay.metrics-for-develocity") {
-                    project.extensions.findByType(MetricsForDevelocityExtension::class.java)?.let { ext ->
-                        with(ext) {
-                            develocityServerUrl.convention(gradleExt.server)
-                            develocityAccessKey.convention(gradleExt.accessKey)
-                        }
-                    }
-                }
-                // Configure tasks wanting to consume the Gradle Enterprise configuration:
-                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
-                    // `convention` to allow for possible override by the property value
-                    task.develocityServerUrl.convention(gradleExt.server)
-                }
-            }
-        }
-        settings.plugins.withId("com.gradle.develocity") {
-            val gradleExt = settings.extensions.getByType(DevelocityConfiguration::class.java)
-            settings.gradle.afterProject { project ->
-                project.plugins.withId("com.ebay.metrics-for-develocity") {
-                    project.extensions.findByType(MetricsForDevelocityExtension::class.java)?.let { ext ->
-                        with(ext) {
-                            develocityServerUrl.convention(gradleExt.server)
-                            develocityAccessKey.convention(gradleExt.accessKey)
-                        }
-                    }
-                }
-                // Configure tasks wanting to consume the Develocity configuration:
-                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
-                    // `convention` to allow for possible override by the property value
-                    task.develocityServerUrl.convention(gradleExt.server)
-                }
-            }
-        }
-
-        // Look for task names that have a datetime or duration suffix and feed those into a property that the
-        // plugin can consume in order to pro-actively create the consumable configurations.
-        settings.gradle.lifecycle.beforeProject { project ->
-            if (project.parent == null) {
-                val requestedTimeSpecs = mutableListOf<String>()
-                project.gradle.startParameter.taskRequests.forEach { taskRequest ->
-                    taskRequest.args.forEach { taskName ->
-                        DATETIME_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
-                            matchResult.groups[1]?.value?.let {
-                                requestedTimeSpecs.add(it)
-                            }
-                        }
-                        DURATION_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
-                            matchResult.groups[1]?.value?.let {
-                                requestedTimeSpecs.add(it)
-                            }
-                        }
-                    }
-                }
-                val autoProperties = requestedTimeSpecs.joinToString(separator = ",")
-                project.extensions.extraProperties.set(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO, autoProperties)
-            }
-        }
-    }
-
-    private fun applyProject(project: Project) {
+    override fun apply(project: Project) {
         project.dependencies.attributesSchema.attribute(SUMMARIZER_ATTRIBUTE)
         project.dependencies.attributesSchema.attribute(TIME_SPEC_ATTRIBUTE)
 

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
  * generate aggregate metric data based upon Develocity build scans.
  */
 @Suppress("unused") // False positive
-internal class MetricsForDevelocityPlugin @Inject constructor(
+internal class MetricsForDevelocityProjectPlugin @Inject constructor(
     private val providerFactory: ProviderFactory
 ) : Plugin<Any> {
 
@@ -49,7 +49,7 @@ internal class MetricsForDevelocityPlugin @Inject constructor(
 
     private fun applySettings(settings: Settings) {
         settings.gradle.lifecycle.beforeProject { project ->
-            project.plugins.apply(MetricsForDevelocityPlugin::class.java)
+            project.plugins.apply(MetricsForDevelocityProjectPlugin::class.java)
         }
 
         // If we are using the gradle property to configure the develocity URL, pass this

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocitySettingsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocitySettingsPlugin.kt
@@ -1,0 +1,112 @@
+package com.ebay.plugins.metrics.develocity
+
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.DEVELOCITY_SERVER_URL_PROPERTY
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES_AUTO
+import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_SUFFIX_PATTERN
+import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_SUFFIX_PATTERN
+import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import org.gradle.api.initialization.Settings
+
+/**
+ * Settings Plugin implementation which applies the Metrics for Develocity plugin to
+ * the project.
+ *
+ * This plugin does the following:
+ * - Adds the project plugin to all projects in the build
+ * - Transfers the configuration of the Develocity (or Gradle Enterprise) plugin to the
+ *   Metrics for Develocity plugin's extension as a conventional default, when applied.
+ * - Scans requested task names for time specifications and passes the gathered information
+ *   to the project plugin.
+ */
+@Suppress("unused") // false positive
+internal class MetricsForDevelocitySettingsPlugin : MetricsForDevelocityPlugin<Settings> {
+
+    override fun apply(settings: Settings) {
+        settings.gradle.lifecycle.beforeProject { project ->
+            project.plugins.apply(MetricsForDevelocityProjectPlugin::class.java)
+        }
+
+        // If we are using the gradle property to configure the develocity URL, pass this
+        // info into the tasks that may consume it.  This is used in preference to the
+        // value configured by the develocity or gradle enterprise plugins, when applied.
+        settings.providers.gradleProperty(DEVELOCITY_SERVER_URL_PROPERTY).orNull?.let { url ->
+            settings.gradle.beforeProject { project ->
+                project.tasks.withType(DevelocityConfigurationInputs::class.java) { task ->
+                    // `set` instead of `convention` since specification by property value should
+                    // take precedence over the default value.
+                    task.develocityServerUrl.set(url)
+                }
+            }
+        }
+
+        // Auto-configure the Gradle Enterprise access if the plugin is applied and has been
+        // directly configured with a server URL and/or access key.
+        settings.plugins.withId("com.gradle.enterprise") {
+            // The Develocity plugin is also registered under this ID so we need to avoid running
+            // this logic when this is the case.
+            if (settings.plugins.hasPlugin("com.gradle.develocity")) {
+                return@withId
+            }
+
+            @Suppress("DEPRECATION") // GradleEnterpriseExtension is deprecated
+            val gradleExt = settings.extensions.getByType(com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension::class.java)
+            settings.gradle.afterProject { project ->
+                project.plugins.withId("com.ebay.metrics-for-develocity") {
+                    project.extensions.findByType(MetricsForDevelocityExtension::class.java)?.let { ext ->
+                        with(ext) {
+                            develocityServerUrl.convention(gradleExt.server)
+                            develocityAccessKey.convention(gradleExt.accessKey)
+                        }
+                    }
+                }
+                // Configure tasks wanting to consume the Gradle Enterprise configuration:
+                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
+                    // `convention` to allow for possible override by the property value
+                    task.develocityServerUrl.convention(gradleExt.server)
+                }
+            }
+        }
+        settings.plugins.withId("com.gradle.develocity") {
+            val gradleExt = settings.extensions.getByType(DevelocityConfiguration::class.java)
+            settings.gradle.afterProject { project ->
+                project.plugins.withId("com.ebay.metrics-for-develocity") {
+                    project.extensions.findByType(MetricsForDevelocityExtension::class.java)?.let { ext ->
+                        with(ext) {
+                            develocityServerUrl.convention(gradleExt.server)
+                            develocityAccessKey.convention(gradleExt.accessKey)
+                        }
+                    }
+                }
+                // Configure tasks wanting to consume the Develocity configuration:
+                project.tasks.withType(DevelocityConfigurationInputs::class.java).configureEach { task ->
+                    // `convention` to allow for possible override by the property value
+                    task.develocityServerUrl.convention(gradleExt.server)
+                }
+            }
+        }
+
+        // Look for task names that have a datetime or duration suffix and feed those into a property that the
+        // plugin can consume in order to pro-actively create the consumable configurations.
+        settings.gradle.lifecycle.beforeProject { project ->
+            if (project.parent == null) {
+                val requestedTimeSpecs = mutableListOf<String>()
+                project.gradle.startParameter.taskRequests.forEach { taskRequest ->
+                    taskRequest.args.forEach { taskName ->
+                        DATETIME_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
+                            matchResult.groups[1]?.value?.let {
+                                requestedTimeSpecs.add(it)
+                            }
+                        }
+                        DURATION_SUFFIX_PATTERN.matchEntire(taskName)?.let { matchResult ->
+                            matchResult.groups[1]?.value?.let {
+                                requestedTimeSpecs.add(it)
+                            }
+                        }
+                    }
+                }
+                val autoProperties = requestedTimeSpecs.joinToString(separator = ",")
+                project.extensions.extraProperties.set(SUPPORTED_CONFIGURATION_PROPERTIES_AUTO, autoProperties)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This makes each plugin a bit more self-contained, rather than conflating them.