### PR TITLE
Consistently use gradle.lifecycle API

### DIFF
--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
+org.gradle.unsafe.isolated-projects=true
 
 # These args need to match the ones in the root project's gradle.properties file
 kotlin.daemon.jvmargs=-Xmx8g -XX:+UseParallelGC


### PR DESCRIPTION
Consistently use the new lifecycle API and reorganize code in order to heads closer to project isolation