### PR TITLE
Bump develocity-api-kotlin from  2024.3.0 to 2025.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ebay-graphAnalytics = "1.1.0"
 # https://github.com/gabrielfeo/develocity-api-kotlin
-develocityApi = "2024.3.0"
+develocityApi = "2025.1.1"
 # https://plugins.gradle.org/plugin/com.gradle.develocity
 gradle-develocity = "3.19.2"
 # https://plugins.gradle.org/plugin/com.gradle.plugin-publish


### PR DESCRIPTION
Changes proposed in this pull request:

- Bump develocity-api-kotlin version from  2024.3.0 to 2025.1.1, supporting newer Develocity API endpoints and parameters 
- Update usage of the library to breaking changes in this major release, leading to simplified code
  - Remove comment about the `OkHttpClient.Builder` issue as the underlying issue is resolved in this version, but preserve code itself to keep the custom timeout
  - Add server URL validation for full control over the error message. The library now requires a strongly-typed `URI` instance instead of a `String`
  - Remove `logLevel` argument as the library no longer supports it. Gradle provides its own SLF4J implementation and builds can use Gradle's `--debug` to view debug-level logs

Library releases:

- [2025.1.0](https://github.com/gabrielfeo/develocity-api-kotlin/releases/tag/2025.1.0)
- [2025.1.1](https://github.com/gabrielfeo/develocity-api-kotlin/releases/tag/2025.1.1)
