### PR TITLE
Remove `<url>=` prefix from access key

### DIFF
--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/service/DevelocityBuildService.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/service/DevelocityBuildService.kt
@@ -18,7 +18,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
 import java.net.URI
-import java.util.Properties
+import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
@@ -34,7 +34,7 @@ abstract class DevelocityBuildService @Inject constructor(
 ): BuildService<DevelocityBuildServiceParameters>, DevelocityService, AutoCloseable {
     private val serverUrl by lazy { resolveServer() }
 
-    private val accessKey by lazy { "${serverUrl}=${resolveAccessKey(serverUrl)}" }
+    private val accessKey by lazy { resolveAccessKey(serverUrl) }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val dispatcher by lazy {
@@ -137,7 +137,7 @@ abstract class DevelocityBuildService @Inject constructor(
                 props.load(reader)
             }
 
-            return props.getProperty(host) ?: null
+            return props.getProperty(host)
         }
         return null
     }


### PR DESCRIPTION
#78 added a server URL prefix to the access key which broke auth.  Removing the prefix to restore functionality.

Also, cleans up a simple lint issue.