### PR TITLE
Back-up develocity version to 4.0 for maximum compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ ebay-graphAnalytics = "1.1.1"
 # https://github.com/gabrielfeo/develocity-api-kotlin
 develocityApi = "2025.1.1"
 # https://plugins.gradle.org/plugin/com.gradle.develocity
-gradle-develocity = "4.2"
+gradle-develocity = "4.0"
 # https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 gradle-pluginPublish = "2.0.0"
 # https://github.com/Kotlin/kotlinx.coroutines/releases


### PR DESCRIPTION
4.0 is the first version to remove the support for the Gradle Enterprise Plugin.

Consumers requesting newer versions of the plugin will work just fine with Gradle's silent version upgrade.

This fix just prevents folks from having to support certain versions of Develocity (beyond what 4.0 requires).

