### PR TITLE
Update graph-analytics-plugin and rev to 1.5.0 for release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
-version=1.4.1
+version=1.5.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ebay-graphAnalytics = "1.1.1"
+ebay-graphAnalytics = "1.1.2"
 # https://github.com/gabrielfeo/develocity-api-kotlin
 develocityApi = "2025.1.1"
 # https://plugins.gradle.org/plugin/com.gradle.develocity


### PR DESCRIPTION
Updates the graph-analytics-plugin to the latest.

Revs to 1.5.0 for publishing.