### PR TITLE
Remove old `-Xjvm-default=all` compiler arg

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ java {
 project.tasks.withType(KotlinJvmCompile::class.java) {
     compilerOptions {
         allWarningsAsErrors.set(true)
-        freeCompilerArgs.addAll(listOf("-Xjvm-default=all", "-opt-in=kotlin.RequiresOptIn"))
+        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.RequiresOptIn"))
         jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -13,7 +13,7 @@ java {
 project.tasks.withType(KotlinJvmCompile::class.java) {
     compilerOptions {
         allWarningsAsErrors.set(true)
-        freeCompilerArgs.addAll(listOf("-Xjvm-default=all", "-opt-in=kotlin.RequiresOptIn"))
+        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.RequiresOptIn"))
         jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/sample/subproj1/build.gradle.kts
+++ b/sample/subproj1/build.gradle.kts
@@ -13,7 +13,7 @@ java {
 project.tasks.withType(KotlinJvmCompile::class.java) {
     compilerOptions {
         allWarningsAsErrors.set(true)
-        freeCompilerArgs.addAll(listOf("-Xjvm-default=all", "-opt-in=kotlin.RequiresOptIn"))
+        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.RequiresOptIn"))
         jvmTarget.set(JvmTarget.JVM_11)
     }
 }


### PR DESCRIPTION
This value is now the default.  Removing this
improves compatibility between multiple versions
of KGP (e.g., when pulling in this plugin via
an included build)