### PR TITLE
Switch to using Configuration Capabilities for exporting data

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -18,4 +18,4 @@ jobs:
         run: ./gradlew build
       - name: Build Sample
         working-directory: sample
-        run: ./gradlew -PprojectCostGraphAnalysisDuration=PT1H build projectCostReport-PT1H
+        run: ./gradlew -PprojectCostGraphAnalysisEnabled=true -PprojectCostGraphAnalysisDuration=P2D graphAnalysis

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     testImplementation(libs.test.hamcrest)
     testImplementation(libs.test.testng)
+    testImplementation(gradleTestKit())
 }
 
 java {

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -74,13 +74,26 @@ summarizer's output of the data gathering task to a consuming project's
 ### Advanced task wiring
 
 For more advanced use cases where the provided extensions are inadequate, the consuming
-project can create a resolvable Gradle `Configuration` to refer to the root project's
-`Configuration` by name and attribute configuration.  When this approach is used, the resolvable
-`Configuration` should specify the following attributes:
-- [SUMMARIZER_ATTRIBUTE](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
-  with a value of [SUMMARIZER_ALL], which will result in a directory of all summarizer outputs.
-- [TIME_SPEC_ATTRIBUTE](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
-  with a value of the datetime or duration specification (e.g., `2024-10-21` or `P7D`)
+project can create a resolvable Gradle `Configuration` that depends on the root project and
+requires the matching summarizer capability.
+
+Producer configurations declare the capability via `outgoing.capability(...)`; consumers
+constrain the project dependency with `requireCapability(...)`. Use
+[summarizerCapability](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
+to build the notation.
+
+Producer configurations must also re-declare the project's implicit GAV capability, because
+declaring any `outgoing.capability` replaces it.
+
+For all summarizer outputs, pass
+[SUMMARIZER_ALL](../src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt)
+and the datetime or duration specification (e.g., `2024-10-21` or `P7D`).
+
+The intended consumable configuration on the root project must be registered at configuration
+time (see Pre-created `Configuration`s above and gradle#30831).
+Capabilities prevent matching unrelated variants; they do not create a missing producer configuration.
+The producer configuration also declares a `Category` attribute so Gradle will consider it
+during variant-aware resolution (configurations with no attributes are skipped).
 
 At this point, the summarizer output file would ideally be selected via an artifact transform
 provided by this plugin.  Unfortunately, the Gradle API for this is not quite workable at this

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ebay-graphAnalytics = "1.1.2"
+ebay-graphAnalytics = "1.1.2" # keep in sync with sample/settings.gradle.kts
 # https://github.com/gabrielfeo/develocity-api-kotlin
 develocityApi = "2026.1.0"
 # https://plugins.gradle.org/plugin/com.gradle.develocity

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,31 +1,7 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-
-plugins {
-    `embedded-kotlin`
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-project.tasks.withType(KotlinJvmCompile::class.java) {
-    compilerOptions {
-        allWarningsAsErrors.set(true)
-        freeCompilerArgs.addAll(listOf("-opt-in=kotlin.RequiresOptIn"))
-        jvmTarget.set(JvmTarget.JVM_11)
-    }
-}
-
 metricsForDevelocity {
     // The following could be used to change the time zone used by the plugin:
     // zoneId.set("UTC")
 
     // An additional filter may also be supplied:
     // develocityQueryFilter.set("project:andr_core tag:Local")
-}
-
-project.tasks.withType(Test::class.java) {
-    useTestNG()
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -4,4 +4,8 @@ metricsForDevelocity {
 
     // An additional filter may also be supplied:
     // develocityQueryFilter.set("project:andr_core tag:Local")
+
+    // This sample project will hit the community cloud Develocity server so we tightly
+    // restrict concurrency, to be good citizens.
+    develocityMaxConcurrency.set(2)
 }

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
 }
 
 plugins {
+    id("com.ebay.graph-analytics") version("1.1.2") // Keep in sync with version catalogs
     id("com.ebay.metrics-for-develocity")
     id("com.gradle.develocity") version("4.5.0")
     id("com.gradle.common-custom-user-data-gradle-plugin") version("2.8.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        mavenLocal()
     }
 }
 
@@ -16,6 +17,7 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        mavenLocal()
     }
 }
 

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityConstants.kt
@@ -1,7 +1,5 @@
 package com.ebay.plugins.metrics.develocity
 
-import org.gradle.api.attributes.Attribute
-
 /**
  * Constants defined by the plugin which may be used by consuming plugins or build scripts.
  */
@@ -38,26 +36,29 @@ object MetricsForDevelocityConstants {
     internal const val SUPPORTED_CONFIGURATION_PROPERTIES_AUTO = "metricsForDevelocityAutomaticConfigurations"
 
     /**
-     * The variant attribute used to identify the time specification used to generate the
-     * summarizer data.  This is used to disambiguate the configuration when multiple
-     * instances are registered.
-     */
-    val TIME_SPEC_ATTRIBUTE: Attribute<String> = Attribute.of(
-        "com.ebay.metrics-for-develocity.time_spec", String::class.java
-    )
-
-    /**
-     * The variant attribute used to identify what summarizer data is being exported or resolved.
-     * The special value of [SUMMARIZER_ALL] is used will result in a directory containing all
-     * summarizer data.  All other values should be considered reserved at this time.
-     */
-    val SUMMARIZER_ATTRIBUTE: Attribute<String> = Attribute.of(
-        "com.ebay.metrics-for-develocity.summarizer", String::class.java
-    )
-
-    /**
      * The attribute value used to identify the configuration used to export all summarizer data to
      * consuming projects.
      */
     const val SUMMARIZER_ALL = "_all_"
+
+    /**
+     * Group ID used in summarizer configuration capabilities.  This is defined by the plugin
+     * and is not the consuming project's group.
+     */
+    const val SUMMARIZER_CAPABILITY_GROUP = "com.ebay.plugins"
+
+    /**
+     * Version used in summarizer configuration capabilities.  A fixed value is used so that
+     * matching does not depend on `project.version` (often `unspecified`).
+     */
+    const val SUMMARIZER_CAPABILITY_VERSION = "1.0"
+
+    /**
+     * Returns the capability notation for a summarizer configuration variant.
+     *
+     * Example: `com.ebay.metrics-for-develocity:summarizer-_all_-P2D:1.0`
+     */
+    fun summarizerCapability(timeSpec: String, summarizer: String = SUMMARIZER_ALL): String {
+        return "$SUMMARIZER_CAPABILITY_GROUP:metrics-for-develocity-summarizer-$summarizer-$timeSpec:$SUMMARIZER_CAPABILITY_VERSION"
+    }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityExtension.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityExtension.kt
@@ -1,5 +1,6 @@
 package com.ebay.plugins.metrics.develocity
 
+import org.gradle.api.GradleException
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -56,4 +57,23 @@ abstract class MetricsForDevelocityExtension : ExtensionAware {
      * be aggregated/reduced.
      */
     abstract val summarizers: ListProperty<MetricSummarizer<*>>
+
+    /**
+     * Installed by the project plugin to eagerly register a consumable configuration for a
+     * time spec.  Required so variant resolution can see the producer (gradle#30831).
+     */
+    internal var timeSpecConfigurationRegistrar: ((String) -> Boolean)? = null
+
+    /**
+     * Ensures the root project has a consumable configuration for the given datetime or
+     * duration specification.  Returns `false` if the time spec cannot be parsed.
+     */
+    internal fun ensureTimeSpecConfiguration(timeSpec: String): Boolean {
+        val registrar = timeSpecConfigurationRegistrar
+            ?: throw GradleException(
+                "Cannot register metrics-for-develocity configuration; the plugin has not " +
+                        "been applied to the root project."
+            )
+        return registrar(timeSpec)
+    }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocityProjectPlugin.kt
@@ -4,10 +4,9 @@ import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.DEVELOC
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.EXTENSION_NAME
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.QUERY_FILTER_PROPERTY
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
-import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ATTRIBUTE
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUPPORTED_CONFIGURATION_PROPERTIES_AUTO
-import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.summarizerCapability
 import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
 import com.ebay.plugins.metrics.develocity.configcachemiss.ConfigCacheMissPlugin
@@ -17,6 +16,9 @@ import com.ebay.plugins.metrics.develocity.taskduration.TaskDurationPlugin
 import com.ebay.plugins.metrics.develocity.userquery.UserQueryPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Category
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import java.time.Duration
@@ -30,14 +32,12 @@ import javax.inject.Inject
  * Plugin implementation which defines tasks and configurations artifacts which are used to
  * generate aggregate metric data based upon Develocity build scans.
  */
+@Suppress("UnstableApiUsage")
 internal class MetricsForDevelocityProjectPlugin @Inject constructor(
     private val providerFactory: ProviderFactory
 ) : MetricsForDevelocityPlugin<Project> {
 
     override fun apply(project: Project) {
-        project.dependencies.attributesSchema.attribute(SUMMARIZER_ATTRIBUTE)
-        project.dependencies.attributesSchema.attribute(TIME_SPEC_ATTRIBUTE)
-
         if (project.parent == null) {
             applyRootProject(project)
         }
@@ -110,6 +110,11 @@ internal class MetricsForDevelocityProjectPlugin @Inject constructor(
             dateHelper,
             ext,
         )
+
+        // This must be configured prior to the summarizer plugins being added.
+        ext.timeSpecConfigurationRegistrar = { timeSpec ->
+            pluginContext.registerConfigurationTimeSpec(timeSpec)
+        }
 
         // As a workaround, pre-register configurations based upon a comma-delimited list of
         // time specifications provided via gradle properties.
@@ -205,11 +210,14 @@ internal class MetricsForDevelocityProjectPlugin @Inject constructor(
         val date = matcher.group(2)
         val hour: String? = matcher.group(3)
 
+        if (project.configurations.names.contains(configurationName)) {
+            return true
+        }
+
         project.configurations.consumable(configurationName) { config ->
             with(config) {
                 isTransitive = false
-                attributes.attribute(TIME_SPEC_ATTRIBUTE, timeSpec)
-                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+                addSummarizerOutgoingCapabilities(project, timeSpec)
             }
         }
 
@@ -233,6 +241,10 @@ internal class MetricsForDevelocityProjectPlugin @Inject constructor(
 
         val durationStr: String = matcher.group(1)
 
+        if (project.configurations.names.contains(configurationName)) {
+            return true
+        }
+
         // Attempt to parse the duration string to ensure it is valid, prior to configuration
         // registration.
         val taskProvider = runCatching {
@@ -242,12 +254,32 @@ internal class MetricsForDevelocityProjectPlugin @Inject constructor(
         project.configurations.consumable(configurationName) { config ->
             with(config) {
                 isTransitive = false
-                attributes.attribute(TIME_SPEC_ATTRIBUTE, durationStr)
-                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
+                addSummarizerOutgoingCapabilities(project, durationStr)
             }
         }
         project.artifacts.add(configurationName, taskProvider)
         return true
+    }
+
+    /**
+     * Declaring any outgoing capability replaces the implicit project GAV; re-declare it so
+     * this remains a selectable variant of `project(":")`.  String/map notation cannot express
+     * an empty project group, so the implicit capability is provided as a [Capability].
+     *
+     * A [Category] attribute is also required: Gradle does not consider configurations
+     * without attributes during variant-aware resolution.
+     */
+    private fun Configuration.addSummarizerOutgoingCapabilities(project: Project, timeSpec: String) {
+        attributes.attribute(
+            Category.CATEGORY_ATTRIBUTE,
+            project.objects.named(Category::class.java, SUMMARIZER_CATEGORY)
+        )
+        outgoing.capability(object : Capability {
+            override fun getGroup(): String = project.group.toString()
+            override fun getName(): String = project.name
+            override fun getVersion(): String = project.version.toString()
+        })
+        outgoing.capability(summarizerCapability(timeSpec, SUMMARIZER_ALL))
     }
 
     /*
@@ -420,5 +452,9 @@ internal class MetricsForDevelocityProjectPlugin @Inject constructor(
                 }
             }
         }
+    }
+
+    private companion object {
+        const val SUMMARIZER_CATEGORY = "metrics-for-develocity-summarizer"
     }
 }

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocitySettingsPlugin.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/MetricsForDevelocitySettingsPlugin.kt
@@ -18,7 +18,7 @@ import org.gradle.api.initialization.Settings
  * - Scans requested task names for time specifications and passes the gathered information
  *   to the project plugin.
  */
-@Suppress("unused") // false positive
+@Suppress("unused", "UnstableApiUsage") // unused is a false positive
 internal class MetricsForDevelocitySettingsPlugin : MetricsForDevelocityPlugin<Settings> {
 
     override fun apply(settings: Settings) {

--- a/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
+++ b/src/main/kotlin/com/ebay/plugins/metrics/develocity/TaskProviderExtensions.kt
@@ -3,11 +3,13 @@
 package com.ebay.plugins.metrics.develocity
 
 import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ALL
-import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.SUMMARIZER_ATTRIBUTE
-import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.TIME_SPEC_ATTRIBUTE
+import com.ebay.plugins.metrics.develocity.MetricsForDevelocityConstants.summarizerCapability
+import com.ebay.plugins.metrics.develocity.NameUtil.DATETIME_TASK_PATTERN
+import com.ebay.plugins.metrics.develocity.NameUtil.DURATION_TASK_PATTERN
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
@@ -39,6 +41,20 @@ private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
     timeSpec: String,
     summarizerId: String,
 ) {
+    // Isolated projects cannot reach another project's extensions. Root is configured
+    // first; subprojects rely on that registration (or settings-plugin pre-creation).
+    if (project.parent == null) {
+        val registered = project.extensions
+            .getByType(MetricsForDevelocityExtension::class.java)
+            .ensureTimeSpecConfiguration(timeSpec)
+        if (!registered) {
+            throw GradleException("Unable to parse time spec: $timeSpec\n" +
+                    "\tSupported patterns:\n" +
+                    "\t\t'${DATETIME_TASK_PATTERN.pattern()}'\n" +
+                    "\t\t'${DURATION_TASK_PATTERN.pattern()}' (group 1 parsed as a Java duration)")
+        }
+    }
+
     val resolveId = "$name-resolve-$summarizerId"
     val existingConfig = project.configurations.findByName(resolveId)
     val configProvider: Provider<Configuration> = if (existingConfig == null) {
@@ -48,9 +64,11 @@ private fun TaskProvider<out MetricSummarizerTask>.configureInputs(
                 isTransitive = false
                 isCanBeResolved = true
                 isCanBeConsumed = false
-                attributes.attribute(TIME_SPEC_ATTRIBUTE, timeSpec)
-                attributes.attribute(SUMMARIZER_ATTRIBUTE, SUMMARIZER_ALL)
-                dependencies.add(project.dependencies.project(mapOf("path" to ":")))
+                val dep = project.dependencies.project(mapOf("path" to ":")) as ModuleDependency
+                dep.capabilities { caps ->
+                    caps.requireCapability(summarizerCapability(timeSpec, SUMMARIZER_ALL))
+                }
+                dependencies.add(dep)
             }
         }
         resolveConfig

--- a/src/test/kotlin/com/ebay/plugins/metrics/develocity/SubprojectConfigureInputsFunctionalTest.kt
+++ b/src/test/kotlin/com/ebay/plugins/metrics/develocity/SubprojectConfigureInputsFunctionalTest.kt
@@ -1,0 +1,99 @@
+package com.ebay.plugins.metrics.develocity
+
+import org.gradle.testkit.runner.GradleRunner
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.testng.annotations.Ignore
+import org.testng.annotations.Test
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Covers [configureInputs] when the consuming task lives on a **subproject**.
+ *
+ * The producer consumable configuration is registered only via
+ * [MetricsForDevelocityExtension.ensureTimeSpecConfiguration], which is backed by a
+ * registrar installed exclusively on the **root** project's extension
+ * ([MetricsForDevelocityProjectPlugin.applyRootProject]). Subproject
+ * [configureInputs] currently skips that call (`project.parent == null`), so a
+ * subproject task whose name does not contain a time-spec suffix never causes the
+ * root producer configuration to be created.
+ */
+class SubprojectConfigureInputsFunctionalTest {
+
+    @Test
+    @Ignore("This is the situation that currently requires use of the metricsForDevelocityConfigurations property")
+    fun subprojectTaskWithoutTimeSpecSuffixStillCreatesRootProducerConfiguration() {
+        val projectDir = writeFixture()
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(
+                ":consumer:customDurationReport", // <-- Task name does not have time spec suffix
+                "--dry-run",
+                "--stacktrace",
+            )
+            .forwardOutput()
+            .build()
+
+        assertThat(
+            "Root producer gather task must be in the graph so variant resolution " +
+                    "can select the summarizer output (not a sibling plugin's configuration).",
+            result.output,
+            containsString(":metricsForDevelocity-last-P2D"),
+        )
+        assertThat(result.output, containsString(":consumer:customDurationReport"))
+    }
+
+    /**
+     * Control: the settings plugin still infers P2D from a duration-suffixed task name,
+     * which pre-creates the root producer configuration even for a subproject consumer.
+     */
+    @Test
+    fun subprojectTaskWithTimeSpecSuffixCreatesRootProducerConfiguration() {
+        val projectDir = writeFixture()
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(
+                ":consumer:projectCostReport-P2D",
+                "--dry-run",
+                "--stacktrace",
+            )
+            .forwardOutput()
+            .build()
+
+        assertThat(result.output, containsString(":metricsForDevelocity-last-P2D"))
+        assertThat(result.output, containsString(":consumer:projectCostReport-P2D"))
+    }
+
+    private fun writeFixture(): File {
+        val dir = Files.createTempDirectory("mfd-subproject-configure-inputs").toFile()
+        dir.resolve("settings.gradle").writeText(
+            """
+            plugins {
+                id 'com.ebay.metrics-for-develocity'
+            }
+            rootProject.name = 'subproject-configure-inputs-fixture'
+            include 'consumer'
+            """.trimIndent()
+        )
+        // Root must not call inputsFromDuration for P2D; otherwise it would hide the bug.
+        dir.resolve("build.gradle").writeText("\n")
+        val consumerDir = dir.resolve("consumer").apply { mkdirs() }
+        consumerDir.resolve("build.gradle").writeText(
+            """
+            import com.ebay.plugins.metrics.develocity.MetricSummarizerTask
+            import com.ebay.plugins.metrics.develocity.TaskProviderExtensionsKt
+
+            abstract class CustomSummarizerTask extends DefaultTask implements MetricSummarizerTask {}
+
+            def custom = tasks.register('customDurationReport', CustomSummarizerTask)
+            TaskProviderExtensionsKt.inputsFromDuration(custom, project, 'P2D', 'projectCost')
+            """.trimIndent()
+        )
+        return dir
+    }
+}


### PR DESCRIPTION
Using Configurations with only Attribute sets to distinguish them can still result in Gradle failing, unable to ascertain the correct artifact when confronted with ambiguous results.  This is mainly due to the underlying Gradle resolution behavior where a lack of a specific attribute does not prevent a configuration from matching.  When other plugins are creating configurations within a project module, it then becomes fairly easy to run into the scenario where things become ambiguous for Gradle.

This PR adds a test for this scenario and then switches to the use of Gradle Configuration Capabilities.  Capabilities provide the means by which the artifacts can be properly scoped to a specific producer, eliminating the failure mode.

Fixes #102 